### PR TITLE
Pom cleanup and docs

### DIFF
--- a/bean-wrapper-jdbc-template/pom.xml
+++ b/bean-wrapper-jdbc-template/pom.xml
@@ -10,46 +10,5 @@
 	</parent>
 
 	<artifactId>bean-wrapper-jdbc-template</artifactId>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.batch</groupId>
-			<artifactId>spring-batch-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
-
+	<packaging>jar</packaging>
 </project>

--- a/chunk-based-steps/pom.xml
+++ b/chunk-based-steps/pom.xml
@@ -10,46 +10,5 @@
 	</parent>
 
 	<artifactId>chunk-based-steps</artifactId>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.hsqldb</groupId>
-			<artifactId>hsqldb</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-
-		<dependency>
-			<groupId>org.springframework.batch</groupId>
-			<artifactId>spring-batch-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
-
-
+	<packaging>jar</packaging>
 </project>

--- a/container-packaging/pom.xml
+++ b/container-packaging/pom.xml
@@ -10,6 +10,7 @@
 	<artifactId>container-packaging</artifactId>
 	<packaging>jar</packaging>
 
+
 	<build>
 		<plugins>
 			<plugin>
@@ -23,4 +24,5 @@
 			</plugin>
 		</plugins>
 	</build>
+
 </project>

--- a/container-packaging/pom.xml
+++ b/container-packaging/pom.xml
@@ -19,6 +19,11 @@
 				<configuration>
 					<image>
 						<name>${project.artifactId}:latest</name>
+						<env>
+							<!-- JVM can be inferred from maven.compiler.target or other
+							locations, but being specific can be helpful -->
+                            <BP_JVM_VERSION>8</BP_JVM_VERSION>
+                        </env>
 					</image>
 				</configuration>
 			</plugin>

--- a/container-packaging/pom.xml
+++ b/container-packaging/pom.xml
@@ -8,41 +8,18 @@
 	</parent>
 
 	<artifactId>container-packaging</artifactId>
-
-	<properties>
-		<maven.compiler.target>1.8</maven.compiler.target>
-	</properties>
-	
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
-		</dependency>
-	</dependencies>
+	<packaging>jar</packaging>
 
 	<build>
 		<plugins>
 			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-			</plugin>
-			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
-				<version>3.0.1</version>
 				<configuration>
-                    <image>
-                        <env>
-                            <BP_JVM_VERSION>8</BP_JVM_VERSION>
-                        </env>
-                    </image>
-                </configuration>
-				<executions>
-					<execution>
-						<goals>
-							<goal>build-image-no-fork</goal>
-						</goals>
-					</execution>
-				</executions>
+					<image>
+						<name>${project.artifactId}:latest</name>
+					</image>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>

--- a/container-packaging/readme.md
+++ b/container-packaging/readme.md
@@ -5,3 +5,9 @@ Package a SpringBoot application as an [Open Container Initiutive](https://openc
 ### Build
 
 `mvn clean spring-boot:build-image`
+
+Will build and tag a container image
+
+`mvn clean package`
+
+Will build an executable jar for local test and development.

--- a/container-packaging/readme.md
+++ b/container-packaging/readme.md
@@ -1,6 +1,6 @@
 # Container packaging
 
-Package a SpringBoot application as an OCI container.
+Package a SpringBoot application as an [Open Container Initiutive](https://opencontainers.org/) (OCI) container.
 
 ### Build
 

--- a/custom-record-parsing/pom.xml
+++ b/custom-record-parsing/pom.xml
@@ -9,23 +9,5 @@
 	</parent>
 
 	<artifactId>custom-record-parsing</artifactId>
-
-	<name>custom-record-parsing</name>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+	<packaging>jar</packaging>
 </project>

--- a/fixedwidth-reader/pom.xml
+++ b/fixedwidth-reader/pom.xml
@@ -10,33 +10,4 @@
 
 	<artifactId>fixedwidth-reader</artifactId>
 	<packaging>jar</packaging>
-
-	<properties>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<java.version>1.8</java.version>
-	</properties>
-
-	<dependencies>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-batch</artifactId>
-		</dependency>
-	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.springframework.boot</groupId>
-				<artifactId>spring-boot-maven-plugin</artifactId>
-				<dependencies>
-					<dependency>
-						<groupId>org.springframework</groupId>
-						<artifactId>springloaded</artifactId>
-						<version>${spring-loaded.version}</version>
-					</dependency>
-				</dependencies>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
-
 </project>

--- a/readme.md
+++ b/readme.md
@@ -3,9 +3,14 @@
 Working through various Spring Batch scenarios.
 
 - [BeanWrapper JDBC Template](./bean-wrapper-jdbc-template)
+
+Using a Spring BeanWrapperFieldSetMapper to convert flatfile data to a domain model and Spring JDBCTemplate to retrieve from the destination datasource.
+
 - [Chunk-based steps](./chunk-based-steps/)
+- [Container packaging](./container-packaging/)
 - [Custom record parsing](./custom-record-parsing/)
 - [Fixed width reader](./fixedwidth-reader/)
+
 
 ### input-files
 


### PR DESCRIPTION
- use the spring-boot-start-parent and define dependencies that all modules will inherit.  Makes for simple (empty) pom entries in each module
- update readme for container-packaging module